### PR TITLE
avoid opening files for in memory DBs

### DIFF
--- a/src/main/java/io/roastedroot/sqlite4j/SQLiteConnection.java
+++ b/src/main/java/io/roastedroot/sqlite4j/SQLiteConnection.java
@@ -286,10 +286,15 @@ public abstract class SQLiteConnection implements Connection {
             }
         }
 
+        boolean isMemory =
+                fileName.isEmpty()
+                        || ":memory:".equals(fileName)
+                        || fileName.contains("mode=memory");
+
         // load the native DB
         DB db = null;
         try {
-            db = new WasmDB(fs, url, fileName, config);
+            db = new WasmDB(fs, url, fileName, config, isMemory);
         } catch (Exception e) {
             SQLException err = new SQLException("Error opening connection");
             err.initCause(e);


### PR DESCRIPTION
cc. @Melloware

This is the quick and dirty fix for this issue:
https://github.com/quarkiverse/quarkus-jdbc-sqlite4j/issues/11

This week I'll have not a lot of screen time for this, but I'll plan to work on [this issue](https://github.com/roastedroot/sqlite4j/issues/5) soon, meanwhile, the safest way to use this driver is to use:

`quarkus.datasource.jdbc.max-size=1`

but happy to discuss if you have insights/ideas