### PR TITLE
Better FS sharing mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,31 @@ There are 3 operations that will affect the host FileSystem:
 - `restore`: copy the database restore file from the host disk to the in-memory VFS
 - `backup`: copy the in-memory database to the host disk
 
+### Database Instances
+
+When using in-memory databases (e.g., `jdbc:sqlite::memory:`), a new instance of SQLite is created each time a new connection is opened. Therefore, when using a connection pool, we recommend setting both the minimum and maximum pool size to `1` to ensure consistency.  
+
+For example: 
+
+```
+datasource.jdbc.min-size=1
+datasource.jdbc.max-size=1
+```
+
+For filesystem-backed databases, this behavior does not apply as long as at least one connection remains open:
+
+```
+datasource.jdbc.min-size=1
+```
+
+Whenever possible, we recommend using filesystem-backed databases. These databases are loaded into the Virtual File System (VFS) upon the first `connection.open` and remain consistent across connections.  
+
+One way to achieve this is by loading an empty resource from the classpath. For example:  
+
+```
+datasource.jdbc.url=jdbc:sqlite:resource:sample.db
+```
+
 ### Compilation flags
 
 The compilation of SQLite to wasm impose some limitations:

--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,9 @@ Keeping track of the loose ends:
 
 NOTES:
 - WAL journal mode is not supported, tests are commented with // TODO: WAL
-- github720_Incorrect_Update_Count_After_Deleting_Many_Rows is really slow compared to the JNI version: this test is causing the memory_grow opcode to be called a lot of times
+- github720_Incorrect_Update_Count_After_Deleting_Many_Rows is really slow compared to the JNI version: this test is causing the memory_grow opcode to be called a lot of times -> will be improved by the new memory allocation strategy in Chicory
 - disabled most of the ErrorMessageTest tests as they rely on dynamically moving files around, which is not supported
-- disabled the tests relying on multiple threads as it's not supported and shared_cache
+- disabled the tests relying on multiple threads as it's not supported and shared_cache -> attempts to share the same instance show issues with the threading model
 
 - write a new Memory that will bulk grow -> alternatively we can explore looking at: SQLITE_ENABLE_MEMSYS3 -> initial proposal
-- update the README file
 - jimfs without Guava?

--- a/src/main/java/io/roastedroot/sqlite4j/SQLiteConfig.java
+++ b/src/main/java/io/roastedroot/sqlite4j/SQLiteConfig.java
@@ -29,6 +29,7 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -1261,5 +1262,23 @@ public class SQLiteConfig {
 
     public void setGetGeneratedKeys(boolean generatedKeys) {
         this.defaultConnectionConfig.setGetGeneratedKeys(generatedKeys);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SQLiteConfig)) return false;
+        SQLiteConfig that = (SQLiteConfig) o;
+        return openModeFlag == that.openModeFlag
+                && busyTimeout == that.busyTimeout
+                && explicitReadOnly == that.explicitReadOnly
+                && Objects.equals(pragmaTable, that.pragmaTable)
+                && Objects.equals(defaultConnectionConfig, that.defaultConnectionConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                pragmaTable, openModeFlag, busyTimeout, explicitReadOnly, defaultConnectionConfig);
     }
 }

--- a/src/main/java/io/roastedroot/sqlite4j/SQLiteConnectionConfig.java
+++ b/src/main/java/io/roastedroot/sqlite4j/SQLiteConnectionConfig.java
@@ -6,6 +6,7 @@ import io.roastedroot.sqlite4j.date.FastDateFormat;
 import java.sql.Connection;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 /** Connection local configurations */
@@ -150,5 +151,33 @@ public class SQLiteConnectionConfig implements Cloneable {
 
     String transactionPrefix() {
         return beginCommandMap.get(transactionMode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SQLiteConnectionConfig)) return false;
+        SQLiteConnectionConfig that = (SQLiteConnectionConfig) o;
+        return transactionIsolation == that.transactionIsolation
+                && autoCommit == that.autoCommit
+                && getGeneratedKeys == that.getGeneratedKeys
+                && dateClass == that.dateClass
+                && datePrecision == that.datePrecision
+                && Objects.equals(dateStringFormat, that.dateStringFormat)
+                && Objects.equals(dateFormat, that.dateFormat)
+                && transactionMode == that.transactionMode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                dateClass,
+                datePrecision,
+                dateStringFormat,
+                dateFormat,
+                transactionIsolation,
+                transactionMode,
+                autoCommit,
+                getGeneratedKeys);
     }
 }

--- a/src/main/java/io/roastedroot/sqlite4j/core/DB.java
+++ b/src/main/java/io/roastedroot/sqlite4j/core/DB.java
@@ -27,6 +27,7 @@ import io.roastedroot.sqlite4j.SQLiteUpdateListener;
 import java.sql.BatchUpdateException;
 import java.sql.SQLException;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1264,4 +1265,23 @@ public abstract class DB implements Codes {
     public abstract byte[] serialize(String schema) throws SQLException;
 
     public abstract void deserialize(String schema, byte[] buff) throws SQLException;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DB)) return false;
+        DB db = (DB) o;
+        return Objects.equals(url, db.url)
+                && Objects.equals(fileName, db.fileName)
+                && Objects.equals(config, db.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode(url, fileName, config);
+    }
+
+    public static int hashCode(String url, String fileName, SQLiteConfig config) {
+        return Objects.hash(url, fileName, config);
+    }
 }

--- a/src/main/java/io/roastedroot/sqlite4j/core/WasmDBFactory.java
+++ b/src/main/java/io/roastedroot/sqlite4j/core/WasmDBFactory.java
@@ -1,0 +1,45 @@
+package io.roastedroot.sqlite4j.core;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import io.roastedroot.sqlite4j.SQLiteConfig;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.sql.SQLException;
+
+// This class serve to retrieve the right WasmDB instance to the connection
+public class WasmDBFactory {
+    // One single filesystem for all connections
+    // is always needed for backup and restores
+    private FileSystem fs = null;
+    private int instancesCount = 0;
+
+    public WasmDBFactory() {}
+
+    public WasmDB create(String url, String fileName, SQLiteConfig config, boolean isMemory)
+            throws SQLException {
+        // lazily initialized at the opening of the first connection
+        if (fs == null) {
+            fs =
+                    Jimfs.newFileSystem(
+                            Configuration.unix().toBuilder().setAttributeViews("unix").build());
+        }
+
+        instancesCount++;
+        return new WasmDB(fs, url, fileName, config, isMemory);
+    }
+
+    public void close(WasmDB db) throws SQLException {
+        db.close();
+        instancesCount--;
+
+        if (instancesCount <= 0) {
+            try {
+                fs.close();
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to close the shared VirtualFileSystem", e);
+            }
+            fs = null;
+        }
+    }
+}


### PR DESCRIPTION
Fix #5 

I tested various configuration on a Quarkus + Hibernate demo application and I believe this is the best overall configuration.

More specifically, any attempt of sharing the underlying Wasm `Instance` across connections resulted in a ton of concurrency issues.

The best advice is, probably, to always use a filesystem db as multiple instances will work together synchronizing on the VFS.

cc. @melloware with these indications, I'd expect the driver to be fully usable with no surprises